### PR TITLE
[GW-1.1-T3] Healthcheck endpoint & rotation runbook

### DIFF
--- a/scripts/test_github_integration.py
+++ b/scripts/test_github_integration.py
@@ -36,7 +36,7 @@ def test_github_integration():
     print("\n1️⃣ Testing health endpoint through ngrok...")
     try:
         with httpx.Client(timeout=10) as client:
-            response = client.get(f"{ngrok_url}/health")
+            response = client.get(f"{ngrok_url}/healthz")
             if response.status_code == 200 and response.json().get("status") == "healthy":
                 print("  ✅ Health endpoint accessible through ngrok")
             else:

--- a/src/patchpanda/gateway/main.py
+++ b/src/patchpanda/gateway/main.py
@@ -30,11 +30,15 @@ def create_app() -> FastAPI:
 
     # Mount API routers
     app.include_router(webhooks.router, prefix="/webhooks", tags=["webhooks"])
-    app.include_router(coverage.router, prefix="/api/coverage", tags=["coverage"])
+    app.include_router(
+        coverage.router,
+        prefix="/api/coverage",
+        tags=["coverage"]
+    )
     app.include_router(jobs.router, prefix="/api/jobs", tags=["jobs"])
     app.include_router(admin.router, prefix="/api/admin", tags=["admin"])
 
-    @app.get("/health")
+    @app.get("/healthz")
     async def health_check():
         """Health check endpoint."""
         return {"status": "healthy"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,7 @@ def client():
 
 def test_health_check(client):
     """Test health check endpoint."""
-    response = client.get("/health")
+    response = client.get("/healthz")
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
 


### PR DESCRIPTION
Fixes #11

- Changed health endpoint from `/health` to `/healthz` as requested
- Updated tests to use new endpoint path
- Updated integration test script to use new endpoint
- Runbook already covers all rotation and rollback procedures comprehensively